### PR TITLE
Make certain all allocations are align-padded

### DIFF
--- a/DynamicPoolAllocator.hpp
+++ b/DynamicPoolAllocator.hpp
@@ -52,9 +52,14 @@ protected:
     }
   }
 
+  inline std::size_t alignmentAdjust(const std::size_t size) {
+    const std::size_t AlignmentBoundary = 16;
+    return std::size_t (size + (AlignmentBoundary-1)) & ~(AlignmentBoundary-1);
+  }
+
   // Allocate a new block and add it to the list of free blocks
   void allocateBlock(struct Block *&curr, struct Block *&prev, const std::size_t size) {
-    const std::size_t sizeToAlloc = std::max(size, minBytes);
+    const std::size_t sizeToAlloc = std::max(alignmentAdjust(size), minBytes);
     curr = prev = NULL;
     void *data = NULL;
 
@@ -84,8 +89,7 @@ protected:
 
   void splitBlock(struct Block *&curr, struct Block *&prev, const std::size_t size) {
     struct Block *next;
-    const std::size_t AlignmentBoundary = 16;
-    std::size_t alignedsize = (size + (AlignmentBoundary-1)) & ~(AlignmentBoundary-1);
+    const std::size_t alignedsize = alignmentAdjust(size);
 
     if ( curr->size == size || curr->size == alignedsize ) {
       // Keep it


### PR DESCRIPTION
There are two places where allocations are performed:

1. allocateBlock()
2. splitBlock()

splitBlock() was padding out to an aligned amount and allocating aligned sizes of data.
allocateBlock() was not not padding out to perform aligned allocations.

This caused a problem inside of splitBlock that would corrupt the free list and eventually cause overlapping allocations.

This has now been fixed by making sure that both allocateBlock() and splitBlock() are dealing with 16-byte pad-aligned allocations of data.